### PR TITLE
Post melpa merge doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# My Repo Pins  [![CI](https://github.com/NinjaTrappeur/my-repo-pins/actions/workflows/test.yml/badge.svg)](https://github.com/NinjaTrappeur/my-repo-pins/actions/workflows/test.yml)
+# My Repo Pins  [![CI](https://github.com/NinjaTrappeur/my-repo-pins/actions/workflows/test.yml/badge.svg)](https://github.com/NinjaTrappeur/my-repo-pins/actions/workflows/test.yml) [![MELPA](https://melpa.org/packages/my-repo-pins-badge.svg)](https://melpa.org/#/my-repo-pins)
 
 ![Project logo](./doc/assets/logo-white.svg#gh-dark-mode-only)
 ![Project logo](./doc/assets/logo-black.svg#gh-light-mode-only)
@@ -41,6 +41,21 @@ As always, a small demo is worth a thousand words!
 **Alternatively, you can also specify a absolute git URL you want to clone:**
 
 ![Screen capture showcasing my-repo-pins cloning a git repository using a absolute git url before jumping to it](./doc/assets/clone-absolute-url.webp)
+
+## Installation
+
+### Via MELPA (recommended)
+
+This package is available on [MELPA](https://melpa.org). After [adding MELPA to your `packages-archives`](https://melpa.org/#/getting-started), run:
+
+```
+M-x package-install
+my-repo-pins
+```
+
+### Manually
+
+Clone this repository, open the `my-repo-pins.el` file, then, install the package using `M-x package-install-file`.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The idea of the plugin is based on this idea; if the repository URLs can be tran
     │   └── mpv
     └── NinjaTrappeur
         ├── cinny
-        └── my-repo-pins.el
+        └── my-repo-pins
 ```
 
 This Emacs plugin aims to help you navigate this repository tree **and** clone new repositories at the right place in the tree.
@@ -32,15 +32,15 @@ As always, a small demo is worth a thousand words!
 
 **Jump to a local repository you already cloned:**
 
-![Screen capture showcasing my-repo-pins.el jumping to a already checked out repository](./doc/assets/jump-local.webp)
+![Screen capture showcasing my-repo-pins jumping to a already checked out repository](./doc/assets/jump-local.webp)
 
 **Find a repository in a remote forge, clone it, and jump to it:**
 
-![Screen capture showcasing my-repo-pins.el cloning a git repository from a remote forge before jumping to it](./doc/assets/clone-project.webp)
+![Screen capture showcasing my-repo-pins cloning a git repository from a remote forge before jumping to it](./doc/assets/clone-project.webp)
 
 **Alternatively, you can also specify a absolute git URL you want to clone:**
 
-![Screen capture showcasing my-repo-pins.el cloning a git repository using a absolute git url before jumping to it](./doc/assets/clone-absolute-url.webp)
+![Screen capture showcasing my-repo-pins cloning a git repository using a absolute git url before jumping to it](./doc/assets/clone-absolute-url.webp)
 
 ## Quick Start
 
@@ -65,9 +65,9 @@ Binding this command to a global key binding might make things a bit more conven
 
 ### my-repo-pins-code-root - REQUIRED
 
-Path to the directory containing all your projects. `my-repo-pins.el` organize the git repos you'll clone in a tree fashion.
+Path to the directory containing all your projects. `my-repo-pins` organize the git repos you'll clone in a tree fashion.
 
-All the code fetched using `my-repo-pins.el` will end up in this root directory. A tree of subdirectories will be created mirroring the remote clone URL.
+All the code fetched using `my-repo-pins` will end up in this root directory. A tree of subdirectories will be created mirroring the remote clone URL.
 
 For instance, after checking out https://git.savannah.gnu.org/git/emacs/org-mode.git, the source code will live in the my-repo-pins-code-root/git.savannah.gnu.org/git/emacs/org-mode/ local directory
 
@@ -81,11 +81,11 @@ Alist in the form of `("FORGE NAME" . FETCH-FUNCTION)` where `FETCH-FUNCTION` is
 
 ## Fetchers
 
-When a repository cannot be found in the code root directory, `my-repo-pins.el` will try to download it from different forges. By default, it'll try to find it on github.com, gitlab.com, git.sr.ht, and codeberg.org.
+When a repository cannot be found in the code root directory, `my-repo-pins` will try to download it from different forges. By default, it'll try to find it on github.com, gitlab.com, git.sr.ht, and codeberg.org.
 
 ### Re-Using the Default Fetchers for your own Forge Instance
 
-My-repo-pins.el provides some generic fetchers for Gitlab, Sourcehut, and Gitea.
+My-repo-pins provides some generic fetchers for Gitlab, Sourcehut, and Gitea.
 
 You can re-use these generic fetchers for your own forge instance using the following functions:
 
@@ -98,7 +98,7 @@ These functions share the same 4 input arguments:
 - `instance-url`: your instance [FQDN](https://fr.wikipedia.org/wiki/Fully_qualified_domain_name). For instance: `gitlab.gnome.org`, `git.alternativebit.fr`, …
 - `user-name`: the user name for which we want to clone the repository.
 - `repo-name`: name of the repository we want to clone.
-- `callback`: function `My-repo-pins.el` will use to clone the repository once we retrieved the various clone URLs. The callback takes an alist as parameter. The alist being of the form of : `((ssh . SSH-CHECKOUT-URL) (https . HTTPS-CHECKOUT-URL))`.
+- `callback`: function `my-repo-pins` will use to clone the repository once we retrieved the various clone URLs. The callback takes an alist as parameter. The alist being of the form of : `((ssh . SSH-CHECKOUT-URL) (https . HTTPS-CHECKOUT-URL))`.
 
 You can re-use these functions by instantiating them for a specific forge, then by appending this instantiation to the `my-repo-pins-forge-fetchers` variable in your Emacs configuration.
 
@@ -112,7 +112,7 @@ Let's say you want to retrieve repositories from the Gnome Gitlab instance livin
 
 ### Writing your Forge Fetcher from Scratch
 
-You may also want to support a forge for which `my-repo-pins.el` currently does not provide any generic fetcher. In that case, you'll have to write a function in the form of:
+You may also want to support a forge for which `my-repo-pins` currently does not provide any generic fetcher. In that case, you'll have to write a function in the form of:
 
 ```elisp
 (defun your-custom-fetcher (owner repo)
@@ -122,8 +122,8 @@ You may also want to support a forge for which `my-repo-pins.el` currently does 
 
 The function needs to accept two input parameters:
 
-- `owner`: string containing the name of the owner of the query repository. IE. `ninjatrappeur` for the `ninjatrappeur/my-repo-pins.el` query.
-- `repository`: string containing the name of the query repository. IE. `my-repo-pins.el` for the `ninjatrappeur/my-repo-pins.el` query.
+- `owner`: string containing the name of the owner of the query repository. IE. `ninjatrappeur` for the `ninjatrappeur/my-repo-pins` query.
+- `repository`: string containing the name of the query repository. IE. `my-repo-pins` for the `ninjatrappeur/my-repo-pins` query.
 
 This function will return either `nil` in case the query couldn't be found on the remote forge. An alist containing the SSH and HTTPS clone URLs in the form of:
 

--- a/my-repo-pins.el
+++ b/my-repo-pins.el
@@ -281,8 +281,7 @@ If the repo does exists, returns a alist in the form of:
 
 `(
   (ssh . SSH-CHECKOUT-URL)
-  (https . HTTPS-CHECKOUT-URL)
-)
+  (https . HTTPS-CHECKOUT-URL))
 
 Returns nil if the repo does not exists."
   (set-buffer response-buffer)
@@ -319,8 +318,7 @@ If the repo does exists, returns a alist in the form of:
 
 `(
   (ssh . SSH-CHECKOUT-URL)
-  (https . HTTPS-CHECKOUT-URL)
-)
+  (https . HTTPS-CHECKOUT-URL))
 
 Returns nil if the repo does not exists."
   (set-buffer response-buffer)

--- a/my-repo-pins.el
+++ b/my-repo-pins.el
@@ -299,7 +299,7 @@ Returns nil if the repo does not exists."
 ;; Gitea Fetcher
 (defun my-repo-pins--query-gitea-owner-repo (instance-url user-name repo-name callback)
   "Queries the INSTANCE-URL gitea instance to retrieve a repo informations.
-This function will first try to dertermine whether the
+This function will first try to determine whether the
 USER-NAME/REPO-NAME exists.
 
 If so, calls the CALLBACK function with a alist containing the ssh and
@@ -430,7 +430,7 @@ Errors out if ‘my-repo-pins-code-root’ has not been set yet."
 This library isn't available for Emacs > 25.1. Vendoring it for
 backward compatibility.
 
-We take advantage of vendoring this function to taylor it a bit more
+We take advantage of vendoring this function to tailor it a bit more
 for our needs.
 
 Return list of all git repositories under directory DIR. This function works

--- a/my-repo-pins.el
+++ b/my-repo-pins.el
@@ -4,7 +4,7 @@
 ;;; Author: Félix Baylac Jacqué <felix at alternativebit.fr>
 ;;; Maintainer: Félix Baylac Jacqué <felix at alternativebit.fr>
 ;;; Version: 0.1
-;;; Homepage: https://github.com/NinjaTrappeur/my-repo-pins.el
+;;; Homepage: https://github.com/NinjaTrappeur/my-repo-pins
 ;;; Package-Requires: ((emacs "26.1"))
 ;;; License:
 ;;

--- a/my-repo-pins.el
+++ b/my-repo-pins.el
@@ -46,7 +46,7 @@
 ;;     │   └── mpv
 ;;     └── NinjaTrappeur
 ;;         ├── cinny
-;;         └── my-repo-pins.el
+;;         └── my-repo-pins
 ;;
 ;; The main entry point of this package is the my-repo-pins command.
 ;; Using it, you can either:
@@ -88,7 +88,7 @@
 (eval-when-compile (require 'subr-x))
 
 (defgroup my-repo-pins-group nil
-  "Variables used to setup the my-repo-pins.el project manager."
+  "Variables used to setup the my-repo-pins project manager."
   :group 'Communication)
 
 ;; Internal: git primitives
@@ -362,9 +362,9 @@ each kind of format, it'll return something along the line of:
 \"https://full-url.org/path/to/git/repo/checkout\"))
 or
 \(('tag . 'owner-repo) ('owner . \"NinjaTrappeur\") ('repo\
-. \"my-repo-pins.el\"))
+. \"my-repo-pins\"))
 or
-\(('tag . 'repo) ('repo . \"my-repo-pins.el\"))"
+\(('tag . 'repo) ('repo . \"my-repo-pins\"))"
   (cond
    ;; Full-url case
    ((or (string-match "^https?://.*/.*/.*$" query-str)
@@ -405,10 +405,10 @@ CLONE-STR being the git clone URL we want to find the local path for."
 
 (defcustom my-repo-pins-code-root nil
   "Root directory containing all your projects.
-my-repo-pins.el organise the git repos you'll checkout in a tree
+my-repo-pins organise the git repos you'll checkout in a tree
 fashion.
 
-All the code fetched using my-repo-pins.el will end up in this root directory. A
+All the code fetched using my-repo-pins will end up in this root directory. A
 tree of subdirectories will be created mirroring the remote URI.
 
 For instance, after checking out
@@ -520,7 +520,7 @@ We're going to draw these forge query status results in a buffer and
 associate each of them with a key binding.
 
 , ‘my-repo-pins--draw-forge-status’ is in charge of
-drawing the forge status in the my-repo-pins.el buffer."
+drawing the forge status in the my-repo-pins buffer."
   (let* (
         (my-repo-pins-buffer (get-buffer-create "my-repo-pins-ui-buffer"))
         (my-repo-pins-window nil)


### PR DESCRIPTION
- Fix the homepage link. cf. https://github.com/NinjaTrappeur/my-repo-pins/issues/3
- Remove unnecessary `.el` suffix when mentioning my-repo-pins.
- Add install instructions.