### PR TITLE
[bugfix] Support more clone full URLs

### DIFF
--- a/my-repo-pins-tests.el
+++ b/my-repo-pins-tests.el
@@ -378,6 +378,27 @@ it'll get deleted before the end of the test."
            (my-repo-pins--parse-repo-identifier "https://github.com/Ninjatrappeur/my-repo-pins.el")
            '((tag . full-url) (full-url . "https://github.com/Ninjatrappeur/my-repo-pins.el"))))
   (should (equal
+           (my-repo-pins--parse-repo-identifier "git@github.com:NinjaTrappeur/my-repo-pins.git")
+           '((tag . full-url) (full-url . "git@github.com:NinjaTrappeur/my-repo-pins.git"))))
+  (should (equal
+           (my-repo-pins--parse-repo-identifier "git://sourceware.org/git/elfutils.git")
+           '((tag . full-url) (full-url . "git://sourceware.org/git/elfutils.git"))))
+  (should (equal
+           (my-repo-pins--parse-repo-identifier "ssh://sourceware.org/git/elfutils.git")
+           '((tag . full-url) (full-url . "ssh://sourceware.org/git/elfutils.git"))))
+  (should (equal
+           (my-repo-pins--parse-repo-identifier "ftp://sourceware.org/git/elfutils.git")
+           '((tag . full-url) (full-url . "ftp://sourceware.org/git/elfutils.git"))))
+  (should (equal
+           (my-repo-pins--parse-repo-identifier "ftps://sourceware.org/git/elfutils.git")
+           '((tag . full-url) (full-url . "ftps://sourceware.org/git/elfutils.git"))))
+  (should (equal
+           (my-repo-pins--parse-repo-identifier "user@sourceware.org/git/elfutils.git")
+           '((tag . full-url) (full-url . "user@sourceware.org/git/elfutils.git"))))
+  (should (equal
+           (my-repo-pins--parse-repo-identifier "sourceware.org/git/elfutils.git")
+           '((tag . full-url) (full-url . "sourceware.org/git/elfutils.git"))))
+  (should (equal
            (my-repo-pins--parse-repo-identifier "github.com/Ninjatrappeur/my-repo-pins.el")
            '((tag . full-url) (full-url . "github.com/Ninjatrappeur/my-repo-pins.el"))))
   (should (equal

--- a/my-repo-pins.el
+++ b/my-repo-pins.el
@@ -399,7 +399,8 @@ or
   (cond
    ;; Full-url case
    ((or (string-match "^https?://.*/.*/.*$" query-str)
-        (string-match "^.*/.*/.*$" query-str))
+        (string-match "^.*/.*/.*$" query-str)
+        (string-match "^.*@.*:?.*$" query-str))
     `((tag . full-url) (full-url . ,query-str)))
    ;; owner/repo case
    ((string-match "^.*/.*$" query-str)


### PR DESCRIPTION
Supporting the git/ssh scheme for fully qualified URLs.

Quoting https://git-scm.com/docs/git-clone#_git_urls:

> The following syntaxes may be used with them:
>
>   ssh://[user@]host.xz[:port]/path/to/repo.git/
>   git://host.xz[:port]/path/to/repo.git/
>   http[s]://host.xz[:port]/path/to/repo.git/
>   ftp[s]://host.xz[:port]/path/to/repo.git/
>
> An alternative scp-like syntax may also be used with the ssh protocol:
>   [user@]host.xz:path/to/repo.git/

Fixes #14 