### PR TITLE
Reformat git command output newlines

### DIFF
--- a/my-repo-pins-tests.el
+++ b/my-repo-pins-tests.el
@@ -335,6 +335,17 @@ it'll get deleted before the end of the test."
        (should (not (file-exists-p (concat tmpdir "/destination"))))
        (delete-directory tmpdir t)
        (funcall done)))))
+;; Git filter Tests
+;;;;;;;;;;;;;;
+
+(ert-deftest my-repo-pins--test-call-git-in-dir-process-filter ()
+  "Test the ‘my-repo-pins--test-call-git-in-dir-process-filter’ filter."
+  (should (equal (my-repo-pins--call-git-in-dir-process-filter (format "hello%cworld" 13)) "hello\nworld"))
+  (should (equal (my-repo-pins--call-git-in-dir-process-filter "hello\nworld") "hello\nworld"))
+  (should (equal (my-repo-pins--call-git-in-dir-process-filter "hello\rworld\ranother\rline") "hello\nworld\nanother\nline"))
+  (should (equal (my-repo-pins--call-git-in-dir-process-filter "hello\nworld\nanother\nline") "hello\nworld\nanother\nline"))
+)
+
 ;; Test Fetchers
 ;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
```
[bugfix] Reformat git command output newlines

The git stdout newline separator is customizable. Sadly for us, it
seems like it uses a carriage return (CR) separator by default. Emacs
won't treat CR as a newline, it needs a CR;LF.

We can configure git to use CR;LF, that being said, we don't want to
modify the user's git configuration here.

Adding a process filter to rewrite the newline separators on the go.
```

Fixes #17 